### PR TITLE
Strip whitespace to avoid filter-injected br

### DIFF
--- a/inline_highlight.rb
+++ b/inline_highlight.rb
@@ -16,6 +16,9 @@ module Jekyll
 			code.strip
 		end
 
+		def render(context)
+			super.strip
+		end
 	end
 end
 


### PR DESCRIPTION
Without this, a `<br />` gets forcibly injected by Liquid before and after the inline code causing awkward newlines.  This removes those br's so that the inline code is truly inline (e.g. when inside a p tag).
