### PR TITLE
Fix plugin install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Unfortunately this syntax highlighting can’t be used in the middle of a paragr
 
 ## Installation
 
-The easiest way to install this plugin is with RubyGems: `gem install jekyll_inline_highlight`.
+The easiest way to install this plugin is to add the [jekyll_inline_highlight.rb file](/lib/jekyll_inline_highlight.rb) to a folder named `_plugins` in your Jekyll project.
 
 ## Usage
 


### PR DESCRIPTION
I ran a clean Jekyll (v3.1.3) install and `sudo gem install jekyll_inline_highlight` on my Mac (v10.11.4) with Ruby (v2.3.0) without adding `jekyll_inline_highlight.rb` in the `_plugins` folder. I added an ihighlight tag to a page and got the error: `jekyll 3.1.3 | Error:  Liquid syntax error (line 1): Unknown tag 'ihighlight'`

I modified the install instruction to fix this by adding the plugin to `_plugins` instead of running `gem install jekyll_inline_highlight`.
